### PR TITLE
Publishing builds from travis to artifactory.broadinstitute.org.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ scala:
   - 2.11.7
 jdk:
   - oraclejdk8
-
 script: sbt clean coverage test
-after_success: sbt 'set unmanagedSourceDirectories in Compile := Seq(file("."))' coveralls
+after_success:
+  - sbt coveralls
+  - src/bin/publish_snapshot.sh
+deploy:
+  provider: script
+  script: src/bin/publish_release.sh
+  on:
+    tags: true

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,21 @@
-import com.typesafe.sbt.SbtGit._
+import com.typesafe.sbt.SbtGit.GitCommand
 
 name := "lenthall"
-
-version := "0.13-SNAPSHOT"
 
 organization := "org.broadinstitute"
 
 scalaVersion := "2.11.7"
+
+// Upcoming release, or current if we're on the master branch
+git.baseVersion := "0.13"
+
+// Shorten the git commit hash
+git.gitHeadCommit := git.gitHeadCommit.value map { _.take(7) }
+
+// Travis will deploy tagged releases, add -SNAPSHOT for all local builds
+git.gitUncommittedChanges := true
+
+versionWithGit
 
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.2.1",
@@ -18,7 +27,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.5" % Test
 )
 
-shellPrompt := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), version.value)}
+shellPrompt := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), git.baseVersion.value)}
 
 scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,14 +4,4 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
 
-// Manually uploaded sbt-coveralls custom build to hybrid ivy/maven, without the Resolver.PluginPattern, due to
-// artifactory bug: https://www.jfrog.com/jira/browse/RTFACT-6235
-resolvers += Resolver.url("artifactory-plugin-snapshots",
-  new URL("https://artifactory.broadinstitute.org/artifactory/plugins-snapshot"))(
-    Patterns(true, "[organisation]/[module]/[revision]/[artifact](-[classifier]).[ext]")
-  )
-
-// Waiting for https://github.com/scoverage/sbt-coveralls/issues/63 to be released
-// Also, when bumping the version, see if this other issue is fixed, and remove the customizations to after_success
-// in .travis.yml: https://github.com/scoverage/sbt-coveralls/issues/62
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.1-c64417d-SNAPSHOT")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")

--- a/src/bin/publish_release.sh
+++ b/src/bin/publish_release.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "TRAVIS_TAG='$TRAVIS_TAG'"
+
+sbt \
+    'set test in Test := {}' \
+    "set version := \"${TRAVIS_TAG}\"" \
+    'set isSnapshot := false' \
+    'set resolvers += Resolver.url("bintray-sbt-plugin-releases", url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)' \
+    'set publishTo := Option("artifactory-publish" at "https://artifactory.broadinstitute.org/artifactory/libs-release-local;build.timestamp=" + new java.util.Date().getTime)' \
+    "set credentials += Credentials(\"Artifactory Realm\", \"artifactory.broadinstitute.org\", \"${ARTIFACTORY_USERNAME}\", \"${ARTIFACTORY_PASSWORD}\")" \
+    publish 2>&1 | sed 's/.*set credentials.*/REDACTED LOG LINE/'

--- a/src/bin/publish_snapshot.sh
+++ b/src/bin/publish_snapshot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "TRAVIS_BRANCH='$TRAVIS_BRANCH'"
+echo "TRAVIS_PULL_REQUEST='$TRAVIS_PULL_REQUEST'"
+
+if [ "$TRAVIS_BRANCH" == "develop" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    sbt \
+        'set test in Test := {}' \
+        'set resolvers += Resolver.url("bintray-sbt-plugin-releases", url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)' \
+        'set publishTo := Option("artifactory-publish" at "https://artifactory.broadinstitute.org/artifactory/libs-snapshot-local;build.timestamp=" + new java.util.Date().getTime)' \
+        "set credentials += Credentials(\"Artifactory Realm\", \"artifactory.broadinstitute.org\", \"${ARTIFACTORY_USERNAME}\", \"${ARTIFACTORY_PASSWORD}\")" \
+        publish 2>&1 | sed 's/.*set credentials.*/REDACTED LOG LINE/'
+fi


### PR DESCRIPTION
Builds from the `develop` branch will be published as git labeled snapshots.
Tagged builds will be deployed as releases.