### PR TITLE
Updated dependencies to the latest versions.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "lenthall"
 
 organization := "org.broadinstitute"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 // Upcoming release, or current if we're on the master branch
 git.baseVersion := "0.18"
@@ -19,22 +19,22 @@ versionWithGit
 
 val sprayV = "1.3.3"
 
-val akkaV = "2.3.12"
+val akkaV = "2.4.10"
 
 libraryDependencies ++= Seq(
-  "com.typesafe" % "config" % "1.2.1",
-  "org.slf4j" % "slf4j-api" % "1.7.7",
+  "com.typesafe" % "config" % "1.3.0",
+  "org.slf4j" % "slf4j-api" % "1.7.21",
   //---------- Provided libraries -------------------//
-  "org.scalaz" %% "scalaz-core" % "7.1.4" % Provided,
-  "ch.qos.logback" % "logback-classic" % "1.1.3" % Provided,
-  "org.webjars" % "swagger-ui" % "2.1.1" % Provided,
+  "org.scalaz" %% "scalaz-core" % "7.2.5" % Provided,
+  "ch.qos.logback" % "logback-classic" % "1.1.7" % Provided,
+  "org.webjars" % "swagger-ui" % "2.2.2" % Provided,
   "io.spray" %% "spray-routing" % sprayV % Provided,
   "io.spray" %% "spray-http" % sprayV % Provided,
   "io.spray" %% "spray-can" % sprayV % Provided,
   "com.typesafe.akka" %% "akka-actor" % akkaV % Provided,
   //---------- Test libraries -------------------//
   "io.spray" %% "spray-testkit" % sprayV % Test,
-  "org.scalatest" %% "scalatest" % "2.2.5" % Test
+  "org.scalatest" %% "scalatest" % "3.0.0" % Test
 )
 
 shellPrompt := { state => "%s| %s> ".format(GitCommand.prompt.apply(state), git.baseVersion.value)}
@@ -64,3 +64,5 @@ testOptions in Test += Tests.Setup(classLoader =>
     .getMethod("getLogger", classLoader.loadClass("java.lang.String"))
     .invoke(null, "ROOT")
 )
+
+testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDSI")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")

--- a/src/main/scala/lenthall/config/ConfigValidationException.scala
+++ b/src/main/scala/lenthall/config/ConfigValidationException.scala
@@ -7,6 +7,6 @@ import scalaz.NonEmptyList
 case class ConfigValidationException(configurationContext: String, errors: NonEmptyList[String]) extends RuntimeException with MessageAggregation {
   def this(context: String, errorMessage: String) = this(context, NonEmptyList(errorMessage))
 
-  override val errorMessages = errors.list
+  override val errorMessages = errors.list.toList
   def exceptionContext = s"Invalid $configurationContext configuration"
 }

--- a/src/main/scala/lenthall/test/actor/TestActorSystem.scala
+++ b/src/main/scala/lenthall/test/actor/TestActorSystem.scala
@@ -2,6 +2,9 @@ package lenthall.test.actor
 
 import akka.actor.ActorSystem
 
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
 /**
  * Provides an individual ActorSystem for tests.
  * An alternative to the NOT thread-safe TestKit, that may run into problems with parallel testing.
@@ -17,9 +20,9 @@ object TestActorSystem {
     try {
       f(system)
     } finally {
-      system.shutdown()
+      system.terminate()
       if (awaitTermination)
-        system.awaitTermination()
+        Await.ready(system.whenTerminated, Duration.Inf)
     }
   }
 }

--- a/src/test/scala/lenthall/spray/SprayCanHttpServiceSpec.scala
+++ b/src/test/scala/lenthall/spray/SprayCanHttpServiceSpec.scala
@@ -37,7 +37,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       port should be > 0
       unbound should be(Http.Unbound)
 
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
   }
 
@@ -55,7 +55,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       port should be > 0
       unbound should be(Http.Unbound)
 
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
   }
 
@@ -73,7 +73,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       port should be > 0
       unbound should be(Http.Unbound)
 
-      assert(system.isTerminated)
+      assert(system.whenTerminated.isCompleted)
     }
   }
 
@@ -90,7 +90,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       exception should be(an[IllegalArgumentException])
       exception.getMessage should be("port out of range:-1")
 
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
   }
 
@@ -107,7 +107,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       exception should be(an[IllegalArgumentException])
       exception.getMessage should be("port out of range:-1")
 
-      assert(system.isTerminated)
+      assert(system.whenTerminated.isCompleted)
     }
   }
 
@@ -127,7 +127,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       exception should be(a[BindFailedException])
       unbound should be(Http.Unbound)
 
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
   }
 
@@ -164,7 +164,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       unbound should be(Http.Unbound)
       exception should be(an[UnbindTimeoutException])
 
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
   }
 
@@ -184,7 +184,7 @@ class SprayCanHttpServiceSpec extends FlatSpec with Matchers with ScalaFutures w
       unbound should be(Http.Unbound)
       exception should be(an[UnbindTimeoutException])
 
-      assert(system.isTerminated)
+      assert(system.whenTerminated.isCompleted)
     }
   }
 

--- a/src/test/scala/lenthall/spray/SwaggerUiHttpServiceSpec.scala
+++ b/src/test/scala/lenthall/spray/SwaggerUiHttpServiceSpec.scala
@@ -26,7 +26,7 @@ trait SwaggerUiResourceHttpServiceSpec extends SwaggerUiHttpServiceSpec with Swa
 SwaggerUiResourceHttpService
 
 object SwaggerUiHttpServiceSpec {
-  val TestSwaggerUiVersion = "2.1.1"
+  val TestSwaggerUiVersion = "2.2.2"
   val SwaggerIndexPreamble =
     """
       |<!DOCTYPE html>

--- a/src/test/scala/lenthall/test/actor/TestActorSystemSpec.scala
+++ b/src/test/scala/lenthall/test/actor/TestActorSystemSpec.scala
@@ -5,6 +5,7 @@ import akka.testkit._
 import lenthall.test.actor.TestActorSystem._
 import org.scalatest.{Assertions, FlatSpec, Matchers}
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class TestActorSystemSpec extends FlatSpec with Matchers with Assertions {
@@ -15,10 +16,10 @@ class TestActorSystemSpec extends FlatSpec with Matchers with Assertions {
     withActorSystem { system =>
       system.name should be("test-system")
       lentSystem = system
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
-    // Should always be terminated
-    assert(lentSystem.isTerminated)
+    // Should always be completed
+    assert(lentSystem.whenTerminated.isCompleted)
   }
 
   it should "create and start shutting down a named system" in {
@@ -28,9 +29,9 @@ class TestActorSystemSpec extends FlatSpec with Matchers with Assertions {
       system.name should be("my-name")
       timeout = 1.second.dilated(system)
       lentSystem = system
-      assert(!system.isTerminated)
+      assert(!system.whenTerminated.isCompleted)
     }
     // As we told the block not to wait, we're going to wait a bit for this termination
-    lentSystem.awaitTermination(timeout)
+    Await.ready(lentSystem.whenTerminated, timeout)
   }
 }


### PR DESCRIPTION
Printing test times, minimal stack traces, and resummarizing tests failures, via http://www.scalatest.org/user_guide/running_your_tests.