### PR TITLE
added type alias Checked

### DIFF
--- a/src/main/scala/lenthall/package.scala
+++ b/src/main/scala/lenthall/package.scala
@@ -1,0 +1,6 @@
+import cats.data.NonEmptyList
+
+package object lenthall {
+  type Checked[A] = Either[NonEmptyList[String], A]
+
+}


### PR DESCRIPTION
I know @geoffjentry doesn't particularly like package objects, but I think this approach is superior to creating a package and named object to hold a single type alias.

Also @cjllanwarne had requested `toValid` and `fromValid`, but those are present in cats' `toValidated` and `toEither` via `cats.syntax.either._`.

