### PR TITLE
Make A in ErrorOr[A] covariant (i.e. its now ErrorOr[+A])

### DIFF
--- a/src/main/scala/lenthall/package.scala
+++ b/src/main/scala/lenthall/package.scala
@@ -1,6 +1,6 @@
 import cats.data.NonEmptyList
 
 package object lenthall {
-  type Checked[A] = Either[NonEmptyList[String], A]
+  type Checked[+A] = Either[NonEmptyList[String], A]
 
 }

--- a/src/main/scala/lenthall/validation/ErrorOr.scala
+++ b/src/main/scala/lenthall/validation/ErrorOr.scala
@@ -7,7 +7,7 @@ import cats.syntax.traverse._
 import cats.instances.list._
 
 object ErrorOr {
-  type ErrorOr[A] = Validated[NonEmptyList[String], A]
+  type ErrorOr[+A] = Validated[NonEmptyList[String], A]
 
   implicit class ShortCircuitingFlatMap[A](val fa: ErrorOr[A]) extends AnyVal {
     /**


### PR DESCRIPTION
Since `ErrorOr[A]` is a type alias where `A` is covariant (both params of `Validated` are covariant):
`type ErrorOr[A] = Validated[NonEmptyList[String], A]`
`A` should be marked covariant in `ErrorOr[A]` as well.