### PR TITLE
pre-unification compiler options cleanup

### DIFF
--- a/src/main/scala/lenthall/test/actor/TestActorSystem.scala
+++ b/src/main/scala/lenthall/test/actor/TestActorSystem.scala
@@ -21,8 +21,10 @@ object TestActorSystem {
       f(system)
     } finally {
       system.terminate()
-      if (awaitTermination)
+      if (awaitTermination) {
         Await.ready(system.whenTerminated, Duration.Inf)
+        ()
+      }
     }
   }
 }

--- a/src/main/scala/lenthall/test/logging/TestLogger.scala
+++ b/src/main/scala/lenthall/test/logging/TestLogger.scala
@@ -23,7 +23,7 @@ class TestLogger(slf4jLogger: Slf4jLogger) {
   private val logger = slf4jLogger.asInstanceOf[Logger]
 
   private val streamAppender = new OutputStreamAppender[ILoggingEvent] {
-    override def start() {
+    override def start(): Unit = {
       logByteStream.reset()
       setOutputStream(logByteStream)
       super.start()
@@ -44,7 +44,7 @@ class TestLogger(slf4jLogger: Slf4jLogger) {
 
   def messages = logByteStream.toString
 
-  def cleanup() {
+  def cleanup(): Unit = {
     logger.detachAppender(streamAppender)
     logger.setLevel(originalLevel)
   }

--- a/src/main/scala/lenthall/util/TryUtil.scala
+++ b/src/main/scala/lenthall/util/TryUtil.scala
@@ -10,7 +10,10 @@ object TryUtil {
   private def stringifyFailure[T](failure: Try[T]): String = {
     val stringWriter = new StringWriter()
     val writer = new PrintWriter(stringWriter)
-    failure recover { case e => e.printStackTrace(writer) }
+    failure match {
+      case Failure(e) => e.printStackTrace(writer)
+      case Success(_) =>
+    }
     writer.flush()
     writer.close()
     stringWriter.toString

--- a/src/test/scala/lenthall/test/actor/TestActorSystemSpec.scala
+++ b/src/test/scala/lenthall/test/actor/TestActorSystemSpec.scala
@@ -17,6 +17,7 @@ class TestActorSystemSpec extends FlatSpec with Matchers with Assertions {
       system.name should be("test-system")
       lentSystem = system
       assert(!system.whenTerminated.isCompleted)
+      ()
     }
     // Should always be completed
     assert(lentSystem.whenTerminated.isCompleted)
@@ -30,6 +31,7 @@ class TestActorSystemSpec extends FlatSpec with Matchers with Assertions {
       timeout = 1.second.dilated(system)
       lentSystem = system
       assert(!system.whenTerminated.isCompleted)
+      ()
     }
     // As we told the block not to wait, we're going to wait a bit for this termination
     Await.ready(lentSystem.whenTerminated, timeout)

--- a/src/test/scala/lenthall/validation/ErrorOrSpec.scala
+++ b/src/test/scala/lenthall/validation/ErrorOrSpec.scala
@@ -226,7 +226,7 @@ class ErrorOrSpec extends FlatSpec with Matchers {
          |}
          |
          |""".stripMargin)
-
+    result
   }
 
 }


### PR DESCRIPTION
When lenthall gets folded into über Cromwell its code will face the pedantry of Cromwell's much stricter compiler options. This breaks out the required changes so they're easier to review.